### PR TITLE
New command to print pub key for a domain. Enhancements to canary creation. Changes to canary structure.

### DIFF
--- a/canary.go
+++ b/canary.go
@@ -16,8 +16,13 @@ const TimestampLayout string = time.RFC3339
 // StandardVersion represents the current standard version being used by this library
 const StandardVersion string = "0.1"
 
-// AuthorName is the name given to the author.
-const AuthorName string = "author"
+const (
+	// RoleAuthor is the role of a author.
+	RoleAuthor string = "author"
+
+	// RoleCosigner is the role of a author.
+	RoleCosigner string = "cosigner"
+)
 
 // CanaryClaim the claims that conform this canary
 type CanaryClaim struct {
@@ -47,8 +52,10 @@ type CanarySignatureSet struct {
 }
 
 type PublicKey struct {
-	// Signer is the name of the signer.
-	Signer string `json:"signer"`
+	// Role is the role of the signer.
+	Role string `json:"role"`
+	// Name is the name of the signer.
+	Name string `json:"name"`
 	// Key is the public key
 	Key string `json:"key"`
 	// Required is true if required for verification.
@@ -106,7 +113,7 @@ func (v *CanaryValidator) Validate() (bool, error) {
 	for _, pubKey := range v.Canary.Claim.PublicKeys {
 		_, ok := v.Canary.Signatures[pubKey.Key]
 		if pubKey.Required && !ok {
-			return false, fmt.Errorf("required signature not found from the signer %q", pubKey.Signer)
+			return false, fmt.Errorf("required signature not found from the signer %q", pubKey.Name)
 		}
 		if ok {
 			signedCount++


### PR DESCRIPTION
1. Now the signer looks like this for example with a "role" and "name". If you mention a name for the author's key, it will be updated accordingly.
   ```        "pubkeys": [
            {
                "role": "author",
                "name": "testing",
                "key": "f6bz99D1pkM2Vgqh/gDnF2X/sbLqe1TMBYoeqC/Lazo=",
                "required": true
            },
            {
                "role": "cosigner",
                "name": "aexr",
                "key": "398aysd",
                "required": true
            },
            {
                "role": "cosigner",
                "name": "xyz",
                "key": "sd897gasd",
                "required": true
            },
            {
                "role": "cosigner",
                "name": "1cq",
                "key": "234234",
                "required": false
            },
            {
                "role": "cosigner",
                "name": "abc",
                "key": "asd6a8s7d6sd",
                "required": false
            }
        ],
   ```
2. `./canarytail canary pubkey <domain>` will now print your domain name.
3. Canary creation and update does not print the canary to stdout anymore. It mentions the path where the canary is stored on the disk.